### PR TITLE
blocks/carousel: config and display fixes

### DIFF
--- a/block_carousel.php
+++ b/block_carousel.php
@@ -104,7 +104,11 @@ class block_carousel extends block_base {
 
         $height = $config->height;
 
-        for ($c = 0; $c < count($config->title); $c++) {
+        foreach ($config->image as $c => $imageid) {
+            if (empty($imageid)) {
+                // Don't show slides without an image.
+                continue;
+            }
             $title = $config->title[$c];
             $text = $config->text[$c];
             $url = $config->url[$c];
@@ -176,6 +180,7 @@ class block_carousel extends block_base {
         for ($c = 0; $c < count($data->image); $c++) {
             file_save_draft_area_files($data->image[$c], $this->context->id, 'block_carousel', 'slide', $c);
         }
+
         parent::instance_config_save($config, $nolongerused);
     }
 

--- a/edit_form.php
+++ b/edit_form.php
@@ -22,6 +22,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+require_once($CFG->dirroot.'/blocks/carousel/lib.php');
+
 /**
  * Form for editing carousel block instances.
  *
@@ -64,8 +66,8 @@ class block_carousel_edit_form extends block_edit_form {
                 get_string('slideurl', 'block_carousel'));
         $options['config_url']['type'] = PARAM_URL;
 
-        $slidegroup[] = $mform->createElement('filepicker', 'config_image',
-                get_string('slideimage', 'block_carousel'), null, array('accepted_types' => 'image'));
+        $slidegroup[] = $mform->createElement('filemanager', 'config_image',
+                get_string('slideimage', 'block_carousel'), null, block_carousel_file_options());
         $options['config_image']['type'] = PARAM_FILE;
 
         $slidegroup[] = $mform->createElement('html', '<hr>');
@@ -76,4 +78,16 @@ class block_carousel_edit_form extends block_edit_form {
 
     }
 
+    function set_data($defaults) {
+        if (!empty($this->block->config) && is_object($this->block->config)) {
+            for ($c = 0; $c < count($this->block->config->image); $c++) {
+                $draftid_editor = file_get_submitted_draft_itemid("image[$c]");
+                file_prepare_draft_area($draftid_editor, $this->block->context->id, 'block_carousel', 'slide', $c,
+                    block_carousel_file_options());
+                $this->block->config->image[$c] = $draftid_editor;
+            }
+        }
+
+        parent::set_data($defaults);
+    }
 }

--- a/edit_form.php
+++ b/edit_form.php
@@ -70,7 +70,8 @@ class block_carousel_edit_form extends block_edit_form {
 
         $slidegroup[] = $mform->createElement('html', '<hr>');
 
-        $this->repeat_elements($slidegroup, 3, $options, 'slides', 'add_slides', 1,
+        $repeatcount = empty($this->block->config->image) ? 3 : count($this->block->config->image);
+        $this->repeat_elements($slidegroup, $repeatcount, $options, 'slides', 'add_slides', 1,
                 get_string('addslide', 'block_carousel'), true);
 
     }

--- a/lib.php
+++ b/lib.php
@@ -84,3 +84,14 @@ function block_carousel_pluginfile($course, $birecordorcm, $context, $filearea, 
     send_stored_file($file, null, 0, $forcedownload, $options);
 }
 
+
+function block_carousel_file_options() {
+    global $CFG;
+
+    return array(
+        'accepted_types' => array('image'),
+        'maxfiles' => 1,
+        'maxbytes' => $CFG->maxbytes,
+        'subdirs' => 0
+    );
+}


### PR DESCRIPTION
images would be lost when re-editing the block config, if it
had more than 3 slides, as only 3 slides would be displayed and saved.