### PR TITLE
Fix carousel date checks

### DIFF
--- a/block_carousel.php
+++ b/block_carousel.php
@@ -142,7 +142,7 @@ class block_carousel extends block_base {
 
             // Check release timing.
             if ((!empty($data->timedstart) && time() < $data->timedstart) ||
-                (!empty($data->timedstart) && time() > $data->timedend)) {
+                (!empty($data->timedend) && time() > $data->timedend)) {
                 continue;
             }
 


### PR DESCRIPTION
Timestart was checked for the end date when it should have been both enddate checks