### PR TITLE
Issue #31: Handle missing files better

### DIFF
--- a/block_carousel.php
+++ b/block_carousel.php
@@ -126,7 +126,7 @@ class block_carousel extends block_base {
         if ($slides > 1) {
             $firstslide = reset($data);
             $height = $firstslide['heightres'];
-            if ($height === 0) {
+            if (empty($height)) {
                 $ratio = 1;
             } else {
                 $ratio = ($firstslide['widthres'] / $firstslide['heightres']);
@@ -140,6 +140,11 @@ class block_carousel extends block_base {
             }
             $data = (object) $data;
             if ($data->disabled) {
+                continue;
+            }
+
+            // Filter any files that are not present or broken.
+            if (is_null($data->heightres) && is_null($data->widthres) && $data->contenttype === 'image') {
                 continue;
             }
 

--- a/classes/cache/slide_cache.php
+++ b/classes/cache/slide_cache.php
@@ -141,8 +141,13 @@ class slide_cache implements \cache_data_source {
             $data['widthres'] = 0;
         } else if ($record->contenttype === 'image') {
             $imageinfo = $selectedfile->get_imageinfo();
-            $data['heightres'] = $imageinfo['height'];
-            $data['widthres'] = $imageinfo['width'];
+            if (!$imageinfo) {
+                $data['heightres'] = null;
+                $data['widthres'] = null;
+            } else {
+                $data['heightres'] = $imageinfo['height'];
+                $data['widthres'] = $imageinfo['width'];
+            }
         } else {
             // Use FFMpeg to get resolution.
             $path = $selectedfile->copy_content_to_temp();


### PR DESCRIPTION
The slide cache will still emit warnings for missing files that are configured to be there,
but the carousel will no longer emit constant warnings for bad slide definitions.